### PR TITLE
Use different accounts to find and purge comments

### DIFF
--- a/main.py
+++ b/main.py
@@ -355,6 +355,8 @@ def create_client(role):
     creds = get_credentials(role)
     # Create API client
     youtube = googleapiclient.discovery.build(config.API_SERVICE_NAME, config.API_VERSION, credentials=creds)
+    
+    return youtube
 
 
 def main():


### PR DESCRIPTION
Usar cuentas distintas para buscar los comentarios a banear, y para banearlos en sí mismo. La idea es ampliar el número de peticiones que puedes hacer a la API antes de que empiece a rechazar las peticiones.
NOTA: Si existe un límite por IP (o similares) por parte de google, quizás sería buena idea separar las 2 partes del script (búsqueda y purga), de modo que algunos colaboradores de confianza hiciesen la búsqueda por ti, y a posteriori hiciesen una llamada a una API tuya para formalizar el borrado y baneo.